### PR TITLE
Use documented API to get stream

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ async function getStreamURL(token) {
 async function getRealStreamURL(href, token) {
   console.log('call soundcloud HEAD with stream URL')
   const options = {
-    method: 'HEAD',
+    method: 'GET',
     // redirect: 'manual',
     headers: {
       Authorization: `OAuth ${token}`,
@@ -42,7 +42,8 @@ async function getRealStreamURL(href, token) {
   const url = new URL(href);
   //url.searchParams.set('_status_code_map[302]', 200);
   const res = await fetch(url.toString(), options);
-  return res.url;
+  const {http_mp3_128_url} = await res.json();
+  return http_mp3_128_url;
 }
 
 async function main() {
@@ -50,7 +51,7 @@ async function main() {
   try {
     const token = await getToken();
     const streamUrl = await getStreamURL(token)
-    realSteamURL = await getRealStreamURL(streamUrl, token);
+    realSteamURL = await getRealStreamURL(`${streamUrl}s`, token);
   } catch (e) {
     console.error(e);
   }


### PR DESCRIPTION
So a tad "hacky" as I built the URL with `${streamUrl}s` - but this corresponds to the documented format here - https://developers.soundcloud.com/docs/api/explorer/open-api#/tracks/get_tracks__track_id__streams

Anyway, this method works, but I'm sure it could be cleaned up quickly.

You get a payload with this format, read the CF url you want and load that, no CORS issues as no redirect overriden.

